### PR TITLE
No cards losecon

### DIFF
--- a/client/src/types/game.types.ts
+++ b/client/src/types/game.types.ts
@@ -10,7 +10,7 @@ export interface Game {
   };
   loser?: {
     id: string;
-    suit: CardSuit;
+    suit?: CardSuit;
   };
   players: {
     [playerSocketId: string]: Player;

--- a/server/src/game/manager.ts
+++ b/server/src/game/manager.ts
@@ -164,7 +164,8 @@ export class GameManager {
   public declareLoser(loserId?: string): void {
     const loserPlayerId = loserId ?? this.loserId();
     if (loserPlayerId) {
-      const completedSuit = this.managePlayer(loserPlayerId).completedSetIfExists()
+      const completedSuit =
+        this.managePlayer(loserPlayerId).completedSetIfExists();
       this.update((game) => {
         game.loser = {
           id: loserPlayerId,
@@ -208,7 +209,7 @@ export class GameManager {
 
   public loserId(): string | undefined {
     for (const playerId of this.playerIds()) {
-      if (this.managePlayer(playerId).hasLost()) return playerId
+      if (this.managePlayer(playerId).hasLost()) return playerId;
     }
   }
 
@@ -315,9 +316,9 @@ export class GameManager {
     // If there is a losing player, it will always be the player
     //  who has just gained a card (so no other players need checking)
     if (this.managePlayer(gainingPlayerId).hasLost()) {
-      this.declareLoser(gainingPlayerId)
+      this.declareLoser(gainingPlayerId);
     } else {
-      this.startNewCardPass(gainingPlayerId)
+      this.startNewCardPass(gainingPlayerId);
     }
   }
 

--- a/server/src/player/manager.ts
+++ b/server/src/player/manager.ts
@@ -63,6 +63,12 @@ export class PlayerManager {
     }
   }
 
+  public cardsInHand(): Card[] {
+    const cards = this.snapshot()?.cards.hand;
+    if (!cards) return [];
+    return cards;
+  }
+
   public completedSetIfExists(): CardSuit | undefined {
     const suitCount = Object.entries(this.countEachSuit()) as [
       CardSuit,
@@ -107,16 +113,22 @@ export class PlayerManager {
     return name;
   }
 
+  /**
+   * Checks whether a player has lost.
+   * 
+   * This should only be called when a player has just gained a card.
+   * 
+   * It will not report the right results otherwise - e.g. it is
+   *  possible for a player to have 0 cards but not be the loser.
+   * 
+   * (They are only the loser if they have 0 cards in hand and are
+   *  also due to start a new card pass, but can't.)
+   * 
+   */
   public hasLost(): boolean {
-    if (this.cardsInHand().length === 0) return true
-    if (this.completedSetIfExists()) return true
-    return false
-  }
-
-  public cardsInHand(): Card[] {
-    const cards = this.snapshot()?.cards.hand;
-    if (!cards) return []
-    return cards
+    if (this.cardsInHand().length === 0) return true;
+    if (this.completedSetIfExists()) return true;
+    return false;
   }
 
   public pushNotification(playerNotification: NotificationForPlayer): void {

--- a/server/src/player/manager.ts
+++ b/server/src/player/manager.ts
@@ -1,6 +1,11 @@
 import { cloneDeep } from "lodash";
 import { ServerEvent } from "../../../client/src/types/event.types";
-import { Card, CardId, CardSuit, Player } from "../../../client/src/types/game.types";
+import {
+  Card,
+  CardId,
+  CardSuit,
+  Player,
+} from "../../../client/src/types/game.types";
 import { GameManager, Operation } from "../game/manager";
 import { NotificationForPlayer } from "../../../client/src/types/notification.types";
 
@@ -115,15 +120,15 @@ export class PlayerManager {
 
   /**
    * Checks whether a player has lost.
-   * 
+   *
    * This should only be called when a player has just gained a card.
-   * 
+   *
    * It will not report the right results otherwise - e.g. it is
    *  possible for a player to have 0 cards but not be the loser.
-   * 
+   *
    * (They are only the loser if they have 0 cards in hand and are
    *  also due to start a new card pass, but can't.)
-   * 
+   *
    */
   public hasLost(): boolean {
     if (this.cardsInHand().length === 0) return true;

--- a/server/src/player/manager.ts
+++ b/server/src/player/manager.ts
@@ -1,6 +1,6 @@
 import { cloneDeep } from "lodash";
 import { ServerEvent } from "../../../client/src/types/event.types";
-import { CardId, CardSuit, Player } from "../../../client/src/types/game.types";
+import { Card, CardId, CardSuit, Player } from "../../../client/src/types/game.types";
 import { GameManager, Operation } from "../game/manager";
 import { NotificationForPlayer } from "../../../client/src/types/notification.types";
 
@@ -105,6 +105,18 @@ export class PlayerManager {
     const name = this._pointer()?.name;
     if (!name) throw new Error("Couldn't find a name");
     return name;
+  }
+
+  public hasLost(): boolean {
+    if (this.cardsInHand().length === 0) return true
+    if (this.completedSetIfExists()) return true
+    return false
+  }
+
+  public cardsInHand(): Card[] {
+    const cards = this.snapshot()?.cards.hand;
+    if (!cards) return []
+    return cards
   }
 
   public pushNotification(playerNotification: NotificationForPlayer): void {


### PR DESCRIPTION
This PR fixes an issue around game end.

In Cockroach Poker, a player can lose in two ways:
1. They collect 5 of a suit; or
2. They have 0 cards in hand, and are meant to start a new round (or 'card pass').

The first of these was accounted for, but not the second.

The checking logic for the second of these conditions has now been added in, along with some slight refactoring of the general checking logic.